### PR TITLE
Fix Tensor.save not aware of 1) ElemPart.idx becomes unordered; 2) 'none' backend

### DIFF
--- a/tests/core/test_data_loader.py
+++ b/tests/core/test_data_loader.py
@@ -69,14 +69,16 @@ def worker__test_load_by_index(local_rank: int, world_size: int,
     assert dl.device.type == device_type
     assert dl.shape == (17,)
 
-    idx = torch.arange(5) * 2 + local_rank
-    tensor = dl.partially_load_by_index(idx, chunk_size=3)
+    v = torch.arange(17) * 3 + 1
+
+    torch.manual_seed(2345 + local_rank)
+    idx = torch.randint(0, 17, (20,))
+    tensor = dl.partially_load_by_index(idx, chunk_size=7)
 
     assert tensor.dtype == dtype
     assert tensor.device.type == 'cpu'  # by rank always CPU
 
-    assert torch.equal(torch.arange(5, dtype=dtype) *
-                       6 + 1 + local_rank * 3, tensor)
+    assert torch.equal(v[idx], tensor)
 
 
 have_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA")
@@ -172,13 +174,14 @@ def worker__test_load_full_by_index(local_rank: int, world_size: int,
     assert dl.device.type == device_type
     assert dl.shape == (17, 2)
 
-    idx = torch.arange(5) * 2 + local_rank
-    tensor = dl.partially_load_by_index(idx)
+    torch.manual_seed(2345 + local_rank)
+    idx = torch.randint(0, 17, (20,))
+    tensor = dl.partially_load_by_index(idx, chunk_size=7)
 
     assert tensor.dtype == dtype
     assert tensor.device.type == 'cpu'  # by rank always CPU
 
-    assert torch.equal(torch.full([5, 2], 42, dtype=dtype), tensor)
+    assert torch.equal(torch.full([20, 2], 42, dtype=dtype), tensor)
 
 
 @pytest.mark.parametrize('dtype',
@@ -246,8 +249,9 @@ def worker__test_load_arange_by_index(local_rank: int, world_size: int,
     assert dl.device.type == device_type
     assert dl.shape == (17,)
 
-    idx = torch.arange(5) * 2 + local_rank
-    tensor = dl.partially_load_by_index(idx)
+    torch.manual_seed(2345 + local_rank)
+    idx = torch.randint(0, 17, (20,))
+    tensor = dl.partially_load_by_index(idx, chunk_size=7)
 
     assert tensor.dtype == dtype
     assert tensor.device.type == 'cpu'  # by rank always CPU

--- a/tests/core/test_jit.py
+++ b/tests/core/test_jit.py
@@ -229,7 +229,8 @@ def worker__test_save(local_rank: int, world_size: int,
 
     torch.manual_seed(2345)
     jitted, = esr.compile(
-        [Model(3, model_dev)], backend='torch')  # type: ignore
+        [Model(3, model_dev)], backend='torch'  # type: ignore
+    )
     jitted: Model
     jitted()
 
@@ -244,9 +245,21 @@ def worker__test_save(local_rank: int, world_size: int,
     else:
         fpath = None
 
-    jitted.vertex_tensor.save(fpath, 'vertex')
-    jitted.edge_tensor.save(fpath, 'edge')
-    jitted.tensor.save(fpath, 'replica')
+    from easier.core.module import _dist_save as _orig_dist_save
+
+    def _dist_save_with_chunk_size(tensor, h5d, *, chunk_size=None):
+        # Test when chuck size is smaller than the dataset size.
+        return _orig_dist_save(tensor, h5d, chunk_size=13)
+
+    with patch(f'{_orig_dist_save.__module__}._dist_save') as mock_dist_save:
+        mock_dist_save.side_effect = _dist_save_with_chunk_size
+
+        jitted.vertex_tensor.save(fpath, 'vertex')
+        jitted.edge_tensor.save(fpath, 'edge')
+        jitted.tensor.save(fpath, 'replica')
+
+        # replica.save() does not call _dist_save()
+        assert mock_dist_save.call_count == 2
 
     if local_rank == 0:
         with h5py.File(fpath, 'r') as h5f:

--- a/tests/core/test_module.py
+++ b/tests/core/test_module.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 import easier
 from easier.core.utils import get_random_str
-from tests.utils import when_ngpus_ge_2
+from tests.utils import when_ngpus_ge_2, torchrun_singlenode
 
 
 def fully_load_data(t: easier.Tensor):
@@ -82,6 +82,47 @@ class TestReducer:
         assert torch.equal(res0, res1)
 
 
+def worker__test_collect_save(local_rank: int, world_size: int, dev_type: str):
+    n = 3
+    dev = torch.device(dev_type)
+
+    class M(easier.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.v = easier.Tensor(
+                torch.rand(3, 3, dtype=torch.float64, device=dev),
+                mode='partition'
+            )
+            self.e = easier.Tensor(
+                torch.rand(4, 3, dtype=torch.float64, device=dev),
+                mode='partition'
+            )
+            self.r = easier.Tensor(
+                torch.rand(9, 3, dtype=torch.float64, device=dev),
+                mode='replicate'
+            )
+
+    m = M()
+    [m] = easier.compile([m], backend='none')
+
+    assert torch.equal(m.v.collect(), m.v)
+    assert torch.equal(m.e.collect(), m.e)
+    assert torch.equal(m.r.collect(), m.r)
+
+    fn = get_random_str() + ".hdf5"
+    dir = os.path.join(tempfile.gettempdir(), "easier", "tests")
+    fpath = os.path.join(dir, fn)
+
+    m.v.save(fpath, 'v')
+    m.e.save(fpath, 'e')
+    m.r.save(fpath, 'r')
+
+    with h5py.File(fpath, 'r') as h5f:
+        torch.testing.assert_close(torch.from_numpy(h5f['v'][:]), m.v.cpu())
+        torch.testing.assert_close(torch.from_numpy(h5f['e'][:]), m.e.cpu())
+        torch.testing.assert_close(torch.from_numpy(h5f['r'][:]), m.r.cpu())
+
+
 class TestJitNoneBackendUsage:
     def test_init__dtype(self):
         n = 3
@@ -139,47 +180,12 @@ class TestJitNoneBackendUsage:
         assert m.r.device == cuda0
         assert m.reducer.idx.device == cuda0
 
-    @pytest.mark.usefixtures('dummy_dist_env')
     @pytest.mark.parametrize('dev_type', [
         'cpu',
         pytest.param('cuda', marks=when_ngpus_ge_2)
     ])
     def test_collect_save(self, dev_type: str):
-        n = 3
-        dev = torch.device(dev_type)
-
-        class M(easier.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.v = easier.Tensor(
-                    torch.rand(3, 3, dtype=torch.float64, device=dev),
-                    mode='partition'
-                )
-                self.e = easier.Tensor(
-                    torch.rand(4, 3, dtype=torch.float64, device=dev),
-                    mode='partition'
-                )
-                self.r = easier.Tensor(
-                    torch.rand(9, 3, dtype=torch.float64, device=dev),
-                    mode='replicate'
-                )
-
-        m = M()
-        [m] = easier.compile([m], backend='none')
-
-        assert torch.equal(m.v.collect(), m.v)
-        assert torch.equal(m.e.collect(), m.e)
-        assert torch.equal(m.r.collect(), m.r)
-
-        fn = get_random_str() + ".hdf5"
-        dir = os.path.join(tempfile.gettempdir(), "easier", "tests")
-        fpath = os.path.join(dir, fn)
-
-        m.v.save(fpath, 'v')
-        m.e.save(fpath, 'e')
-        m.r.save(fpath, 'r')
-
-        with h5py.File(fpath, 'r') as h5f:
-            torch.testing.assert_close(torch.from_numpy(h5f['v'][:]), m.v.cpu())
-            torch.testing.assert_close(torch.from_numpy(h5f['e'][:]), m.e.cpu())
-            torch.testing.assert_close(torch.from_numpy(h5f['r'][:]), m.r.cpu())
+        torchrun_singlenode(
+            1, worker__test_collect_save, (dev_type,),
+            init_type=dev_type  # type: ignore
+        )


### PR DESCRIPTION
This PR fixes the issues:
1) Tensor.save is not aware of ElemPart.idx becoming unordered.
2) Tensor.save does not work in 'none' backend.

The background about 1): After adding sparse encoding ElemPart.idx is generally unordered. And if the len(ElemPart.idx) gets larger than chunk_size (128M), the older version, which assume idx is ordered, will fail.

Also update the related unit tests to emphasize the unordered idx and 'none' backend usage.