### PR TITLE
Make GMRES replicated indexes be ndim=1 tensors

### DIFF
--- a/easier/numeric/solver/gmres.py
+++ b/easier/numeric/solver/gmres.py
@@ -57,11 +57,11 @@ class InitW(esr.Module):
         self.V = V
         self.w = w
         self.j = esr.Tensor(
-            torch.tensor(0, dtype=torch.int32, device=V.device),
+            torch.tensor([0], dtype=torch.int32, device=V.device),
             mode='replicate')
 
     def forward(self):
-        self.w[:] = self.A(self.M(self.V[:, ..., self.j]))
+        self.w[:] = self.A(self.M(self.V[:, ..., self.j].squeeze(-1)))
 
 
 class SumW(esr.Module):
@@ -72,11 +72,11 @@ class SumW(esr.Module):
         self.w = w
         self.h = h
         self.i = esr.Tensor(
-            torch.tensor(0, dtype=torch.int32, device=V.device),
+            torch.tensor([0], dtype=torch.int32, device=V.device),
             mode='replicate')
 
     def forward(self):
-        self.h[:] = esr.sum(self.V[:, ..., self.i] * self.w).sum()
+        self.h[:] = esr.sum(self.V[:, ..., self.i].squeeze(-1) * self.w).sum()
 
 
 class NormW(esr.Module):
@@ -98,11 +98,11 @@ class UpdateW(esr.Module):
         self.w = w
         self.h = h
         self.i = esr.Tensor(
-            torch.tensor(0, dtype=torch.int32, device=V.device),
+            torch.tensor([0], dtype=torch.int32, device=V.device),
             mode='replicate')
 
     def forward(self):
-        self.w.sub_(self.h * self.V[:, ..., self.i])
+        self.w.sub_(self.h * self.V[:, ..., self.i].squeeze(-1))
 
 
 class UpdateV(esr.Module):
@@ -113,11 +113,11 @@ class UpdateV(esr.Module):
         self.w = w
         self.h = h
         self.i = esr.Tensor(
-            torch.tensor(0, dtype=torch.int32, device=V.device),
+            torch.tensor([0], dtype=torch.int32, device=V.device),
             mode='replicate')
 
     def forward(self):
-        self.V[:, ..., self.i] = self.w / self.h
+        self.V[:, ..., self.i] = (self.w / self.h)[:, ..., None]
 
 
 class UpdateX(esr.Module):


### PR DESCRIPTION
Make GMRES replicated indexes be `ndim=1 / shape=(1,)` tensors, rather than `ndim=0 / shape=()` tensors.
And adjust input/output shapes using `.squeeze()` and `[...None...]` to unsqueeze, accordingly.

Why this PR:
- When the index is a `ndim=0/shape=()` CUDA tensors, PyTorch native-layer (i.e. libtorch) would copy that tensor to CPU to be a scalar int, and use that CPU int to call the real indexing CUDA subprocedures. Which is an extra CUDA sync.
- As a result of this copy:
  - Libtorch uses `Tensor::item()` to copy. Which results in `cudaMemcpyAsync + cudaStreamSynchronize` calls. (Although asynchronized, PyTorch still appends a `cudaStreamSynchronize` to all such CUDA-CPU copies)
  - From PyTorch 2.x the destination memory in a CUDA-CPU copy starts to be page-locked memory, so the `cudaMemcpyAsync` becomes really async (otherwise this API would block) and returns immediately, it's `cudaStreamSynchronize` to block. Occasionally such sync mechanism takes a relatively long time to finish.

PyTorch behavior about copying the scalar index:
- Merely knowing ndim and shape, PyTorch is able to decide the shape of input/output.
- PyTorch would like to know if the scalar is out-of-range (`in [0, len) or [-len, -1]`) to raise the exception before entering CUDA indexing;
- Arguably less common and delay-able: a torch.Tensor could be a sparse/quantized tensor. In such cases the indexing becomes `libtorch::Tensor::select(..., int index)` etc. Nevertheless libtorch eagerly invokes the copy of the index.