### PR TITLE
[Hotfix] Add explicit dependency networkx; Change Tensor.set_ to Tensor.copy_ in tutorials

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,4 @@ scipy
 torch
 pymetis
 h5py
+networkx

--- a/easier/core/runtime/jit_engine/jit_engine.py
+++ b/easier/core/runtime/jit_engine/jit_engine.py
@@ -253,6 +253,16 @@ class ViewSrcTrackerBase(NodeHandlerBase):
         self.addr2refcount: Dict[int, int] = {}
         self.addr2viewsrc: Dict[int, ViewSrc] = {}
 
+        # TODO record (within storage lifetime) the address of a tensor,
+        # we need the invariant that tensor storage never changes
+        # because they are allocated by EASIER AOT.
+        # E.g. Tensor.set_ resets the storage, but Tensor.copy_ does not.
+        # self.tensor2addr: Dict[torch.Tensor, int] = {}
+        #
+        # NOTE but if it's not an esr.Tensor, but an immediate tensors, can
+        # their storage be changed? We can detect the change and decr refcount
+        # before resetting and incr refcount of the shared storage.
+
     def _get_indexed_addr(
         self, iaddr_node: Node, val: RuntimeValue,
         *,

--- a/tutorial/poisson/assemble_poisson.py
+++ b/tutorial/poisson/assemble_poisson.py
@@ -66,15 +66,15 @@ class PoissonMeshComponentsCollector(esr.Module):
 
         for i in range(3):
             # (ne,)
-            self.src_p[i].set_(src_p[:, i])
-            self.dst_p[i].set_(dst_p[:, i])
+            self.src_p[i].copy_(src_p[:, i])
+            self.dst_p[i].copy_(dst_p[:, i])
 
             # (nc,)
-            self.cells_p[i].set_(self.cells[:, i])
+            self.cells_p[i].copy_(self.cells[:, i])
 
         for i in range(2):
             # (nbc,)
-            self.bp[i].set_(self.bpoints[:, i])
+            self.bp[i].copy_(self.bpoints[:, i])
 
 
 class PoissonInitializer(esr.Module):

--- a/tutorial/shallow_water_equation/assemble_shallow_water.py
+++ b/tutorial/shallow_water_equation/assemble_shallow_water.py
@@ -66,15 +66,15 @@ class ShallowWaterMeshComponentsCollector(esr.Module):
 
         for i in range(3):
             # (ne,)
-            self.src_p[i].set_(src_p[:, i])
-            self.dst_p[i].set_(dst_p[:, i])
+            self.src_p[i].copy_(src_p[:, i])
+            self.dst_p[i].copy_(dst_p[:, i])
 
             # (nc,)
-            self.cells_p[i].set_(self.cells[:, i])
+            self.cells_p[i].copy_(self.cells[:, i])
 
         for i in range(2):
             # (nbc,)
-            self.bp[i].set_(self.bpoints[:, i])
+            self.bp[i].copy_(self.bpoints[:, i])
 
 
 class ShallowWaterInitializer(esr.Module):


### PR DESCRIPTION
Main changes:
- torch 2.x happens to have the dependency `networkx` so it was OK. But we need to explicitly add the dependency.
- Change tutorials to use `Tensor.copy_` instead of `Tensor.set_`.
  - `torch.Tensor.set_(self, value)` resets the storage of `self` tensor to the storage of the input tensor `value`, this may break the assumption that the storage of `esr.Tensor` is allocated and managed by EASIER.
  - Also, current `JitEngine` GC function does not handle the storage resetting well, causing wrong refcount. In `dev` we need to enhance the mechanism (e.g. totally reject resetting; or allow reset except esr.Tensor, etc.)