### PR TITLE
Refactor tensor_group_partition; Prevent collective call timeout due to unbalanced workload

### DIFF
--- a/easier/core/distpart.py
+++ b/easier/core/distpart.py
@@ -9,7 +9,8 @@ import torch
 
 import scipy.sparse
 
-from easier.core.runtime.dist_env import get_runtime_dist_env, unbalanced_compute_heartbeat
+from easier.core.runtime.dist_env import \
+    get_runtime_dist_env, unbalanced_compute_heartbeat
 from easier.core.utils import logger
 import easier.cpp_extension as _C
 
@@ -615,9 +616,10 @@ def coarsen_level(
                 cnv_allocated += this_colocated_n
 
                 # NOTE Remaining `matched` elements are local vertexes
-                # that are matching with remote vertexes (on subsequent workers),
-                # they are processed in the `if rank < w:` part beblow in previous
-                # iterations of those subsequent workers.
+                # that are matching with remote vertexes
+                # (on subsequent workers),
+                # they are processed in the `if rank < w:` part beblow
+                # in previous iterations of those subsequent workers.
                 assert torch.all(cvids != -1), \
                     "All local vertexes should be assigned with coarser IDs"
 

--- a/easier/core/distpart.py
+++ b/easier/core/distpart.py
@@ -9,7 +9,7 @@ import torch
 
 import scipy.sparse
 
-from easier.core.runtime.dist_env import get_runtime_dist_env
+from easier.core.runtime.dist_env import get_runtime_dist_env, unbalanced_compute_heartbeat
 from easier.core.utils import logger
 import easier.cpp_extension as _C
 
@@ -70,22 +70,24 @@ class CoarseningLevel:
         start = sum(self.dist_config.local_nvs[:dist_env.rank])
         local_nv = self.dist_config.local_nvs[dist_env.rank]
 
-        csr = scipy.sparse.csr_matrix(
-            (self.adjwgt, self.colidx, self.rowptr),
-            shape=(local_nv, self.dist_config.nv)
-        )
+        with unbalanced_compute_heartbeat("remove self edges"):
 
-        # csr.setdiag() explicitly stores zero entries,
-        # we need eliminate_zeros() to adjust the CSR sparsity structure.
-        csr.setdiag(0, start)
-        csr.eliminate_zeros()
+            csr = scipy.sparse.csr_matrix(
+                (self.adjwgt, self.colidx, self.rowptr),
+                shape=(local_nv, self.dist_config.nv)
+            )
 
-        rowptr = torch.from_numpy(csr.indptr).to(torch.int64)
-        colidx = torch.from_numpy(csr.indices).to(torch.int64)
-        adjwgt = torch.from_numpy(csr.data).to(torch.int64)
-        return CoarseningLevel(
-            self.dist_config, self.vertex_weights, rowptr, colidx, adjwgt
-        )
+            # csr.setdiag() explicitly stores zero entries,
+            # we need eliminate_zeros() to adjust the CSR sparsity structure.
+            csr.setdiag(0, start)
+            csr.eliminate_zeros()
+
+            rowptr = torch.from_numpy(csr.indptr).to(torch.int64)
+            colidx = torch.from_numpy(csr.indices).to(torch.int64)
+            adjwgt = torch.from_numpy(csr.data).to(torch.int64)
+            return CoarseningLevel(
+                self.dist_config, self.vertex_weights, rowptr, colidx, adjwgt
+            )
 
 
 def _assert_local_map_no_overlap(local_map, new_range):
@@ -338,20 +340,23 @@ def merge_cadj_adjw(
     # these two vertexes may be on same workers,
     # we need to concat their adj lists, unique, and accumulate
     # edge weights accordingly.
-    unmerged_rows = (
-        row_xchg.cvids_unmerged_on_this - row_xchg.c_start
-    ).repeat_interleave(
-        unmerged_row_sizes
-    )
 
-    coarser_graph = scipy.sparse.csr_matrix(
-        (adjwgt_unmerged, (unmerged_rows, cadj_unmerged)),  # sum up dups
-        shape=(row_xchg.local_cnv, row_xchg.c_dist_config.nv)
-    )
+    with unbalanced_compute_heartbeat("merge cadj"):
 
-    return torch.from_numpy(coarser_graph.indptr).to(torch.int64), \
-        torch.from_numpy(coarser_graph.indices).to(torch.int64), \
-        torch.from_numpy(coarser_graph.data).to(torch.int64)
+        unmerged_rows = (
+            row_xchg.cvids_unmerged_on_this - row_xchg.c_start
+        ).repeat_interleave(
+            unmerged_row_sizes
+        )
+
+        coarser_graph = scipy.sparse.csr_matrix(
+            (adjwgt_unmerged, (unmerged_rows, cadj_unmerged)),  # sum up dups
+            shape=(row_xchg.local_cnv, row_xchg.c_dist_config.nv)
+        )
+
+        return torch.from_numpy(coarser_graph.indptr).to(torch.int64), \
+            torch.from_numpy(coarser_graph.indices).to(torch.int64), \
+            torch.from_numpy(coarser_graph.data).to(torch.int64)
 
 
 def map_adj_by_cvids(
@@ -565,18 +570,20 @@ def coarsen_level(
     start, end = prev_lv.dist_config.get_start_end()
     assert prev_lv.rowptr.shape[0] - 1 == end - start
 
-    # Each worker independently calculates heavy-edge matching.
-    # Local vids to global vids
-    matched = torch.full((end - start,), fill_value=-1, dtype=torch.int64)
-    # NOTE `matched` vector is updated within this C call.
-    _C.locally_match_heavy_edge(
-        start,
-        end,
-        matched,
-        prev_lv.rowptr,
-        prev_lv.colidx,
-        prev_lv.adjwgt,
-    )
+    with unbalanced_compute_heartbeat("locally_match_heavy_edge"):
+
+        # Each worker independently calculates heavy-edge matching.
+        # Local vids to global vids
+        matched = torch.full((end - start,), fill_value=-1, dtype=torch.int64)
+        # NOTE `matched` vector is updated within this C call.
+        _C.locally_match_heavy_edge(
+            start,
+            end,
+            matched,
+            prev_lv.rowptr,
+            prev_lv.colidx,
+            prev_lv.adjwgt,
+        )
     # Possible value of matched[x]:
     # -1
     #   unmatched
@@ -595,24 +602,26 @@ def coarsen_level(
     for w in range(dist_env.world_size - 1, -1, -1):
         w_start, w_end = prev_lv.dist_config.get_start_end(w)
 
+        with unbalanced_compute_heartbeat(f"assign cvids rank={w}"):
+            if w == dist_env.rank:
+                this_unmatched_n = assign_cvids_unmatched(
+                    matched, cvids, cnv_allocated
+                )
+                cnv_allocated += this_unmatched_n
+
+                this_colocated_n = assign_cvids_colocated(
+                    start, end, matched, cvids, cnv_allocated
+                )
+                cnv_allocated += this_colocated_n
+
+                # NOTE Remaining `matched` elements are local vertexes
+                # that are matching with remote vertexes (on subsequent workers),
+                # they are processed in the `if rank < w:` part beblow in previous
+                # iterations of those subsequent workers.
+                assert torch.all(cvids != -1), \
+                    "All local vertexes should be assigned with coarser IDs"
+
         if w == dist_env.rank:
-            this_unmatched_n = assign_cvids_unmatched(
-                matched, cvids, cnv_allocated
-            )
-            cnv_allocated += this_unmatched_n
-
-            this_colocated_n = assign_cvids_colocated(
-                start, end, matched, cvids, cnv_allocated
-            )
-            cnv_allocated += this_colocated_n
-
-            # NOTE Remaining `matched` elements are local vertexes
-            # that are matching with remote vertexes (on subsequent workers),
-            # they are processed in the `if rank < w:` part beblow in previous
-            # iterations of those subsequent workers.
-            assert torch.all(cvids != -1), \
-                "All local vertexes should be assigned with coarser IDs"
-
             # TODO make a masked broadcast for only (rank < w) workers.
             w_cvids = dist_env.broadcast(
                 w, cvids.to(dist_env.comm_device)
@@ -631,8 +640,9 @@ def coarsen_level(
 
         w_cvids = w_cvids.cpu()
 
-        if dist_env.rank < w:
-            align_coarser_vids(w_start, w_end, w_cvids, matched, cvids)
+        with unbalanced_compute_heartbeat(f"align cvids rank={w}"):
+            if dist_env.rank < w:
+                align_coarser_vids(w_start, w_end, w_cvids, matched, cvids)
 
     # end for w in range(world_size)
 

--- a/easier/core/jit.py
+++ b/easier/core/jit.py
@@ -279,7 +279,10 @@ def init(
     )
 
     import torch.distributed as dist
-    dist.init_process_group(comm_backend, **kwargs)
+    # dist.init_process_group(comm_backend, **kwargs)
+
+    import datetime
+    dist.init_process_group(comm_backend, timeout=datetime.timedelta(minutes=3), **kwargs)
 
     init_logger(dist.get_rank())
 

--- a/easier/core/jit.py
+++ b/easier/core/jit.py
@@ -279,10 +279,7 @@ def init(
     )
 
     import torch.distributed as dist
-    # dist.init_process_group(comm_backend, **kwargs)
-
-    import datetime
-    dist.init_process_group(comm_backend, timeout=datetime.timedelta(minutes=3), **kwargs)
+    dist.init_process_group(comm_backend, **kwargs)
 
     init_logger(dist.get_rank())
 

--- a/easier/core/passes/sparse_encoding/sparse_encoding.py
+++ b/easier/core/passes/sparse_encoding/sparse_encoding.py
@@ -9,7 +9,7 @@ import torch
 from torch.fx.graph import Graph
 from easier.core.passes.tensor_group_partition import ElemPart
 
-from easier.core.runtime.dist_env import get_runtime_dist_env
+from easier.core.runtime.dist_env import get_runtime_dist_env, unbalanced_compute_heartbeat
 from easier.core.utils import logger
 import easier.core.module as esr
 
@@ -28,7 +28,7 @@ from easier.core.passes.utils import \
 def calculate_paired_in_out_idx(
     input_gidx_part: torch.Tensor,
     output_gidx_part: torch.Tensor,
-    output_elempart: 'ElemPart',
+    output_elempart: 'ElemPart'
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Calculate the data relations a Selector or Reducer specifies, regarding
@@ -83,9 +83,13 @@ def calculate_paired_in_out_idx(
     # and collects output_elempart from all other workers.
     for t in range(dist_env.world_size):
         output_elempart_t = broadcast_elempart(t, output_elempart)
-        gidx_part_this_to_t_mask = isin_elempart(
-            output_gidx_part, output_elempart_t
-        )
+
+        with unbalanced_compute_heartbeat(
+            f"calculate_paired_in_out_idx / {t}"
+        ):
+            gidx_part_this_to_t_mask = isin_elempart(
+                output_gidx_part, output_elempart_t
+            )
 
         # TODO if we really "zip" or `torch.stack` the in/out gidx tensors,
         # we see some similarity in both functions of two calculation phases,
@@ -95,8 +99,8 @@ def calculate_paired_in_out_idx(
 
         # The gidx data itself are stored on this worker, but the specified
         # elements may be not on this worker.
-        input_gidx_to_t = input_gidx_part[gidx_part_this_to_t_mask]
-        output_gidx_on_t = output_gidx_part[gidx_part_this_to_t_mask]
+            input_gidx_to_t = input_gidx_part[gidx_part_this_to_t_mask]
+            output_gidx_on_t = output_gidx_part[gidx_part_this_to_t_mask]
 
         input_gidxes_to_others.append(
             input_gidx_to_t.to(dist_env.comm_device)
@@ -161,22 +165,28 @@ def calculate_halo_info(
     # for all input_elemparts among workers, so we can simplify gidx first.
     # TODO if elemparts are also well-ordered e.g. ArangeIdx, we don't really
     # need to simplify gidx -- doing unique() is slower in such cases.
-    sorted_input_gidx = input_gidx_to_this.unique(sorted=True)
+    with unbalanced_compute_heartbeat(
+        "calculate_halo_info / unique"
+    ):
+        sorted_input_gidx = input_gidx_to_this.unique(sorted=True)
 
     for u in range(dist_env.world_size):
         input_elempart_u = broadcast_elempart(u, input_elempart)
 
-        halo_lidx_u_to_this = elempart_isin(
-            input_elempart_u, sorted_input_gidx, gidx_sorted=True
-        ).argwhere().ravel()
-        halo_lidxes_to_this.append(
-            halo_lidx_u_to_this.to(dist_env.comm_device)
-        )
+        with unbalanced_compute_heartbeat(
+            f"calculate_halo_info / {u}"
+        ):
+            halo_lidx_u_to_this = elempart_isin(
+                input_elempart_u, sorted_input_gidx, gidx_sorted=True
+            ).argwhere().ravel()
+            halo_lidxes_to_this.append(
+                halo_lidx_u_to_this.to(dist_env.comm_device)
+            )
 
-        halo_gidx_u_to_this = input_elempart_u.idx[halo_lidx_u_to_this]
-        halo_gidxes_to_this.append(
-            halo_gidx_u_to_this
-        )
+            halo_gidx_u_to_this = input_elempart_u.idx[halo_lidx_u_to_this]
+            halo_gidxes_to_this.append(
+                halo_gidx_u_to_this
+            )
 
     halo_lidxes_to_others: List[torch.Tensor] = [
         t.cpu() for t in
@@ -201,7 +211,10 @@ def reorder_output_by_selector(
     # NOTE We are NOT reorder the target ElemPart.idx to be sorted,
     # it's just for simplifying the examination of the raw output ElemPart,
     # and `calculate_paired_in_out_idx()` doesn't care of the order at all.
-    _sorted_output_elempart = sort_elempart(output_elempart_to_reorder)
+    with unbalanced_compute_heartbeat(
+        "reorder_selector / sort"
+    ):
+        _sorted_output_elempart = sort_elempart(output_elempart_to_reorder)
 
     input_gidx_to_this, output_gidx_on_this = calculate_paired_in_out_idx(
         input_idx_part,
@@ -211,9 +224,12 @@ def reorder_output_by_selector(
 
     # When output_elempart is loaded, it's already reordered.
     # As Selectors, all output_elempart elements are covered.
-    assert torch.equal(
-        output_gidx_on_this.sort()[0], _sorted_output_elempart.idx
-    )
+    with unbalanced_compute_heartbeat(
+        "reorder_selector / assert / sort"
+    ):
+        assert torch.equal(
+            output_gidx_on_this.sort()[0], _sorted_output_elempart.idx
+        )
 
     halo_gidxes_to_this, _halo_lidxes_to_others = \
         calculate_halo_info(
@@ -223,12 +239,15 @@ def reorder_output_by_selector(
 
     chunk_gidx_space = torch.concat(halo_gidxes_to_this)
 
-    _reordered_input_gidx_to_this, reordered_output_gidx_on_this, _pos = \
-        zipsort_using_order(
-            order=chunk_gidx_space,
-            to_sort=input_gidx_to_this,
-            to_follow=output_gidx_on_this
-        )
+    with unbalanced_compute_heartbeat(
+        f"reorder_selector / zipsort"
+    ):
+        _reordered_input_gidx_to_this, reordered_output_gidx_on_this, _pos = \
+            zipsort_using_order(
+                order=chunk_gidx_space,
+                to_sort=input_gidx_to_this,
+                to_follow=output_gidx_on_this
+            )
 
     # For both Selector and Reducer, on the side of the elempart to reorder,
     # the gidx tensor always has unique element global IDs, e.g.
@@ -285,22 +304,28 @@ def reorder_input_by_reducer(
     # will be related to output elements, on this or other workers.
     # If within the slices, discrete input elements can be reordered, it will
     # finally result in the halo being reordered by `output_elempart`.
-    assert sum(
-        halo_in.shape[0] for halo_in in unordered_halo_gidxes_to_this
-    ) == input_gidx_to_this.unique().shape[0] \
-      == input_gidx_to_this.shape[0], \
-        "each input element of the local Reducer has been prepared as the halo"
-    assert sum(
-        halo_out.shape[0] for halo_out in unordered_halo_lidxes_to_others
-    ) == input_elempart_to_reorder.idx.shape[0], \
-        "each input_elempart element is used once as the halo"
+    with unbalanced_compute_heartbeat(
+        "reorder_reducer / assert / sort"
+    ):
+        assert sum(
+            halo_in.shape[0] for halo_in in unordered_halo_gidxes_to_this
+        ) == input_gidx_to_this.unique().shape[0] \
+        == input_gidx_to_this.shape[0], \
+            "each input element of the local Reducer has been prepared as the halo"
+        assert sum(
+            halo_out.shape[0] for halo_out in unordered_halo_lidxes_to_others
+        ) == input_elempart_to_reorder.idx.shape[0], \
+            "each input_elempart element is used once as the halo"
 
-    _reordered_output_gidx_on_this, reordered_input_gidx_to_this, _pos = \
-        zipsort_using_order(
-            order=output_elempart.idx,
-            to_sort=output_gidx_on_this,
-            to_follow=input_gidx_to_this
-        )
+    with unbalanced_compute_heartbeat(
+        "reorder_reducer / zipsort"
+    ):
+        _reordered_output_gidx_on_this, reordered_input_gidx_to_this, _pos = \
+            zipsort_using_order(
+                order=output_elempart.idx,
+                to_sort=output_gidx_on_this,
+                to_follow=input_gidx_to_this
+            )
 
     # We try to reorder each halo at our best.
     # Intuitively, this will make the reordering Selector pattern less chaotic.
@@ -308,12 +333,15 @@ def reorder_input_by_reducer(
     for u in range(dist_env.world_size):
         unordered_gidx_from_u = unordered_halo_gidxes_to_this[u]
 
-        reordered_gidx_from_u = reordered_input_gidx_to_this[
-            torch.isin(reordered_input_gidx_to_this, unordered_gidx_from_u)
-        ]
-        reordered_halo_gidxes_to_this.append(
-            reordered_gidx_from_u.to(dist_env.comm_device)
-        )
+        with unbalanced_compute_heartbeat(
+            f"reorder_reducer / isin / {u}"
+        ):
+            reordered_gidx_from_u = reordered_input_gidx_to_this[
+                torch.isin(reordered_input_gidx_to_this, unordered_gidx_from_u)
+            ]
+            reordered_halo_gidxes_to_this.append(
+                reordered_gidx_from_u.to(dist_env.comm_device)
+            )
 
     reordered_halo_gidxes_to_others = \
         dist_env.all_to_all(reordered_halo_gidxes_to_this)
@@ -330,10 +358,13 @@ def reorder_input_by_reducer(
     ).cpu()
 
     # input_elempart may be loaded from a previous session
-    assert torch.equal(
-        reordered_input_elempart.sort()[0],
-        input_elempart_to_reorder.idx.sort()[0]
-    )
+    with unbalanced_compute_heartbeat(
+        "reorder_reducer / assert / equal sorted"
+    ):
+        assert torch.equal(
+            reordered_input_elempart.sort()[0],
+            input_elempart_to_reorder.idx.sort()[0]
+        )
 
     return (input_gidx_to_this, output_gidx_on_this), reordered_input_elempart
 
@@ -352,11 +383,14 @@ def rewrite_selector_instance(
     dist_env = get_runtime_dist_env()
     rank = dist_env.rank
 
-    _reordered_output_gidx, reordered_input_gidx, _pos = zipsort_using_order(
-        order=output_elempart.idx,
-        to_sort=output_gidx_on_this,
-        to_follow=input_gidx_to_this
-    )
+    with unbalanced_compute_heartbeat(
+        "rewrite_selector / zipsort"
+    ):
+        _reordered_output_gidx, reordered_input_gidx, _pos = zipsort_using_order(
+            order=output_elempart.idx,
+            to_sort=output_gidx_on_this,
+            to_follow=input_gidx_to_this
+        )
 
     # At runtime, and required by HaloExchanger implementation,
     # the this-to-this halo is not sliced out from tensors of input_elempart,
@@ -368,8 +402,11 @@ def rewrite_selector_instance(
     # The space is concated by many idx pieces,
     # because of sparse encoding and TensorGroup reordering,
     # both intra- and inter-pieces, elements are not monotonically increasing.
-    chunk_gidx_space = torch.concat(halo_gidxes_to_this)
-    rewritten_idx = vector_index_of(reordered_input_gidx, chunk_gidx_space)
+    with unbalanced_compute_heartbeat(
+        "rewrite_selector / index_of"
+    ):
+        chunk_gidx_space = torch.concat(halo_gidxes_to_this)
+        rewritten_idx = vector_index_of(reordered_input_gidx, chunk_gidx_space)
 
     selector.idx = rewritten_idx
     selector.easier_index_status = 'rewritten'
@@ -391,11 +428,14 @@ def rewrite_reducer_instance(
         input_gidx_to_this, input_elempart
     )
 
-    reordered_output_gidx, reordered_input_gidx, _pos = zipsort_using_order(
-        order=output_elempart.idx,
-        to_sort=output_gidx_on_this,
-        to_follow=input_gidx_to_this
-    )
+    with unbalanced_compute_heartbeat(
+        "rewrite_reducer / zipsort"
+    ):
+        reordered_output_gidx, reordered_input_gidx, _pos = zipsort_using_order(
+            order=output_elempart.idx,
+            to_sort=output_gidx_on_this,
+            to_follow=input_gidx_to_this
+        )
 
     # We immediately finding indexes against `reordered_output_gidx`.
     # If the Reducer itself doesn't have such sequentialness, we will insert
@@ -404,10 +444,13 @@ def rewrite_reducer_instance(
     #  chunk --reorderingSelector--> reorderedInputGidx ~~1-1dataRelation~~
     #  reorderedOutputGidx --localReducer--> outputTensor
     #
-    rewritten_idx = vector_index_of(reordered_output_gidx, output_elempart.idx)
+    with unbalanced_compute_heartbeat(
+        "rewrite_selector / index_of"
+    ):
+        rewritten_idx = vector_index_of(reordered_output_gidx, output_elempart.idx)
 
-    chunk_gidx_space = torch.concat(halo_gidxes_to_this)
-    selector_idx = vector_index_of(reordered_input_gidx, chunk_gidx_space)
+        chunk_gidx_space = torch.concat(halo_gidxes_to_this)
+        selector_idx = vector_index_of(reordered_input_gidx, chunk_gidx_space)
 
     # if Selector happens to have idx strictly ==arange(len(idx)), it means:
     # - previously in TensorGroup reordering, this local Reducer

--- a/easier/core/passes/sparse_encoding/sparse_encoding.py
+++ b/easier/core/passes/sparse_encoding/sparse_encoding.py
@@ -9,7 +9,8 @@ import torch
 from torch.fx.graph import Graph
 from easier.core.passes.tensor_group_partition import ElemPart
 
-from easier.core.runtime.dist_env import get_runtime_dist_env, unbalanced_compute_heartbeat
+from easier.core.runtime.dist_env import \
+    get_runtime_dist_env, unbalanced_compute_heartbeat
 from easier.core.utils import logger
 import easier.core.module as esr
 
@@ -310,8 +311,9 @@ def reorder_input_by_reducer(
         assert sum(
             halo_in.shape[0] for halo_in in unordered_halo_gidxes_to_this
         ) == input_gidx_to_this.unique().shape[0] \
-        == input_gidx_to_this.shape[0], \
-            "each input element of the local Reducer has been prepared as the halo"
+          == input_gidx_to_this.shape[0], \
+            "each input element of the local Reducer has been prepared" \
+            " as the halo"
         assert sum(
             halo_out.shape[0] for halo_out in unordered_halo_lidxes_to_others
         ) == input_elempart_to_reorder.idx.shape[0], \
@@ -386,11 +388,12 @@ def rewrite_selector_instance(
     with unbalanced_compute_heartbeat(
         "rewrite_selector / zipsort"
     ):
-        _reordered_output_gidx, reordered_input_gidx, _pos = zipsort_using_order(
-            order=output_elempart.idx,
-            to_sort=output_gidx_on_this,
-            to_follow=input_gidx_to_this
-        )
+        _reordered_output_gidx, reordered_input_gidx, _pos = \
+            zipsort_using_order(
+                order=output_elempart.idx,
+                to_sort=output_gidx_on_this,
+                to_follow=input_gidx_to_this
+            )
 
     # At runtime, and required by HaloExchanger implementation,
     # the this-to-this halo is not sliced out from tensors of input_elempart,
@@ -431,11 +434,12 @@ def rewrite_reducer_instance(
     with unbalanced_compute_heartbeat(
         "rewrite_reducer / zipsort"
     ):
-        reordered_output_gidx, reordered_input_gidx, _pos = zipsort_using_order(
-            order=output_elempart.idx,
-            to_sort=output_gidx_on_this,
-            to_follow=input_gidx_to_this
-        )
+        reordered_output_gidx, reordered_input_gidx, _pos = \
+            zipsort_using_order(
+                order=output_elempart.idx,
+                to_sort=output_gidx_on_this,
+                to_follow=input_gidx_to_this
+            )
 
     # We immediately finding indexes against `reordered_output_gidx`.
     # If the Reducer itself doesn't have such sequentialness, we will insert
@@ -447,7 +451,8 @@ def rewrite_reducer_instance(
     with unbalanced_compute_heartbeat(
         "rewrite_selector / index_of"
     ):
-        rewritten_idx = vector_index_of(reordered_output_gidx, output_elempart.idx)
+        rewritten_idx = vector_index_of(
+            reordered_output_gidx, output_elempart.idx)
 
         chunk_gidx_space = torch.concat(halo_gidxes_to_this)
         selector_idx = vector_index_of(reordered_input_gidx, chunk_gidx_space)

--- a/easier/core/passes/tensor_group_partition.py
+++ b/easier/core/passes/tensor_group_partition.py
@@ -21,7 +21,8 @@ from easier.core.passes.utils import \
     get_selector_reducer_idx_partition_pair, \
     normalize_reducer_call_into_args, normalize_selector_call_into_args, \
     get_easier_tensors
-from easier.core.runtime.dist_env import get_runtime_dist_env, unbalanced_compute_heartbeat
+from easier.core.runtime.dist_env import \
+    get_runtime_dist_env, unbalanced_compute_heartbeat
 from easier.core.distpart import distpart_kway, DistConfig
 from easier.core.utils import EasierJitException, logger
 
@@ -32,7 +33,7 @@ METIS_ADJWGT_REDUCER: int = 10
 def parallel_partition_graph(
     world_size: int, rank: int,
     subadjmat_height: int, adjmat_width: int, vtxdist: torch.Tensor,
-    rowcolids_and_causes: List[Tuple[torch.Tensor, torch.Tensor, 'CommPair']]
+    rowcolids_and_cps: List[Tuple[torch.Tensor, torch.Tensor, 'CommPair']]
 ):
     """
     Args:
@@ -49,12 +50,12 @@ def parallel_partition_graph(
             must form a symmetric sparse matrix.
             (No matter how previous subpasses remap the IDs)
     """
+    # NOTE
+    # - `csr_matrix` sums up duplicated matrix cells during construction
+    # - `csr_matrix` automatically choose int32/int64 for its `indptr` and
+    #   `indices` ndarrays regarding upperbounds of the height and the weight.
     with unbalanced_compute_heartbeat("assemble sparse adjmat"):
 
-        # NOTE
-        # - `csr_matrix` sums up duplicated matrix cells during construction
-        # - `csr_matrix` automatically choose int32/int64 for its `indptr` and
-        #   `indices` ndarrays regarding upperbounds of the height and the weight.
         selector_graph = scipy.sparse.csr_matrix(
             (subadjmat_height, adjmat_width), dtype=np.int32)
         reducer_graph = scipy.sparse.csr_matrix(
@@ -64,7 +65,7 @@ def parallel_partition_graph(
         # - if involved in Selectors, no matter how many times, weights are 1
         # - each time involved in Reducers, those weights are increased by 10,
         #   no matter how many edges there are.
-        for (commpair_rowids, commpair_colids, comm_pair) in rowcolids_and_causes:
+        for (commpair_rowids, commpair_colids, comm_pair) in rowcolids_and_cps:
             assert commpair_rowids.ndim == commpair_colids.ndim == 1
             assert commpair_rowids.shape == commpair_rowids.shape
 
@@ -469,7 +470,7 @@ def partition_tensor_groups_with_adjmat(
         world_size, rank,
         subadjmat_height=subadjmat_height, adjmat_width=int(vtxdist[-1]),
         vtxdist=vtxdist,
-        rowcolids_and_causes=rowcolids_for_commpairs)
+        rowcolids_and_cps=rowcolids_for_commpairs)
 
     return local_membership
 

--- a/easier/core/runtime/dist_env.py
+++ b/easier/core/runtime/dist_env.py
@@ -1226,7 +1226,7 @@ def unbalanced_compute_heartbeat(compute_hint: str = ""):
     min_duration = min(task_duration_list)
     wait_max = max_duration - min_duration
 
-    if wait_max > 0  :# * 60:
+    if wait_max > 1  :# * 60:
         duration_strs = [f'{d:.2f}' for d in task_duration_list]
         logger.debug(
             f"Unbalanced compute '{compute_hint}' waits {wait_max:.2f}s."

--- a/easier/core/runtime/dist_env.py
+++ b/easier/core/runtime/dist_env.py
@@ -1189,10 +1189,10 @@ def unbalanced_compute_heartbeat(compute_hint: str = ""):
     def _poll_thread_fn():
 
         dist_env = get_default_dist_env()
-        sleep = 1
+        sleep = 0.1
         while True:
             time.sleep(sleep)  # sleep up to 5s
-            sleep = min(5, sleep + 1)
+            sleep = min(5, sleep * 2)
 
             with lock:
                 task_duration = task_duration_list[0]

--- a/easier/core/runtime/dist_env.py
+++ b/easier/core/runtime/dist_env.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+from contextlib import contextmanager
 import os
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 import numpy
@@ -1146,3 +1147,88 @@ def get_runtime_dist_env() -> DistEnv:
     if _runtime_device_type is None:
         raise EasierJitException("The device type for runtime isn't set")
     return _get_or_init_dist_env(_runtime_device_type)
+
+
+@contextmanager
+def unbalanced_compute_heartbeat(compute_hint: str = ""):
+    """
+    Run a code section WITHOUT communication on each worker,
+    do periodic heartbeat collective calls to avoid some workers timeout
+    because they finish faster and enter the next collective call ealier.
+
+    NOTE:
+    -   Communication primitives CAN NOT be used in this code section.
+        Otherwise the error of mismatched communication calls will happen.
+    
+    -   Both the `torch.dist` layer and the communication backend itself
+        must be able to be accessed multi-threaded. E.g.:
+        -   (we may need `dist.new_group()` for a dedicated comm group to poll)
+        -   NCCL 2.x allows multithreading after ncclInit, and requires
+            manual serialization of calls;
+        -   MPI must be initialized with thread level higher than
+            MPI_THREAD_SERIALIZED.
+
+    Usage:
+    ```
+    with keep_alive("get_result"):
+        if dist_env.rank == 0:
+            result = lengthy_task() # do task on rank 0
+        elif dist_env.rank == 1:
+            result = 42             # do task on rank 1
+        else:
+            result = None
+    print(result)   # use result that's different on each worker
+    ```
+    """
+    import threading
+    import time
+
+    lock = threading.Lock()
+    task_duration_list: List[float] = [-1]
+
+    def _poll_thread_fn():
+
+        dist_env = get_default_dist_env()
+        sleep = 1
+        while True:
+            time.sleep(sleep)  # sleep up to 5s
+            sleep = min(5, sleep + 1)
+
+            with lock:
+                task_duration = task_duration_list[0]
+
+            all_durations = dist_env.all_gather_into_tensor(
+                torch.tensor([task_duration], device=dist_env.comm_device)
+            )
+            if torch.all(all_durations >= 0):
+
+                # no need to lock
+                task_duration_list.clear()
+                task_duration_list.extend(all_durations.tolist())
+
+                return
+
+    poll_thread = threading.Thread(target=_poll_thread_fn)
+    poll_thread.start()
+
+    start_time = time.time()
+
+    yield
+
+    end_time = time.time()
+
+    with lock:
+        task_duration_list[0] = end_time - start_time  # in sec
+
+    poll_thread.join()
+
+    max_duration = max(task_duration_list)
+    min_duration = min(task_duration_list)
+    wait_max = max_duration - min_duration
+
+    if wait_max > 0  :# * 60:
+        duration_strs = [f'{d:.2f}' for d in task_duration_list]
+        logger.debug(
+            f"Unbalanced compute '{compute_hint}' waits {wait_max:.2f}s."
+            f" All ranks spend: {duration_strs}"
+        )

--- a/easier/core/runtime/dist_env.py
+++ b/easier/core/runtime/dist_env.py
@@ -1198,7 +1198,7 @@ def unbalanced_compute_heartbeat(compute_hint: str = ""):
                 task_duration = task_duration_list[0]
 
             all_durations = dist_env.all_gather_into_tensor(
-                torch.tensor([task_duration], device=dist_env.comm_device)
+                torch.tensor([task_duration], dtype=torch.float64, device=dist_env.comm_device)
             )
             if torch.all(all_durations >= 0):
 

--- a/easier/core/runtime/dist_env.py
+++ b/easier/core/runtime/dist_env.py
@@ -1159,7 +1159,7 @@ def unbalanced_compute_heartbeat(compute_hint: str = ""):
     NOTE:
     -   Communication primitives CAN NOT be used in this code section.
         Otherwise the error of mismatched communication calls will happen.
-    
+
     -   Both the `torch.dist` layer and the communication backend itself
         must be able to be accessed multi-threaded. E.g.:
         -   (we may need `dist.new_group()` for a dedicated comm group to poll)
@@ -1197,9 +1197,11 @@ def unbalanced_compute_heartbeat(compute_hint: str = ""):
             with lock:
                 task_duration = task_duration_list[0]
 
-            all_durations = dist_env.all_gather_into_tensor(
-                torch.tensor([task_duration], dtype=torch.float64, device=dist_env.comm_device)
-            )
+            all_durations = dist_env.all_gather_into_tensor(torch.tensor(
+                [task_duration],
+                dtype=torch.float64,
+                device=dist_env.comm_device
+            ))
             if torch.all(all_durations >= 0):
 
                 # no need to lock
@@ -1226,7 +1228,7 @@ def unbalanced_compute_heartbeat(compute_hint: str = ""):
     min_duration = min(task_duration_list)
     wait_max = max_duration - min_duration
 
-    if wait_max > 1  :# * 60:
+    if wait_max > 5 * 60:
         duration_strs = [f'{d:.2f}' for d in task_duration_list]
         logger.debug(
             f"Unbalanced compute '{compute_hint}' waits {wait_max:.2f}s."

--- a/easier/core/runtime/dist_env.py
+++ b/easier/core/runtime/dist_env.py
@@ -1189,6 +1189,9 @@ def unbalanced_compute_heartbeat(compute_hint: str = ""):
     def _poll_thread_fn():
 
         dist_env = get_default_dist_env()
+
+        # Start with a very small interval, to prevent small-scale workloads
+        # waiting too long.
         sleep = 0.1
         while True:
             time.sleep(sleep)  # sleep up to 5s

--- a/tests/core/passes/test_tensor_partition.py
+++ b/tests/core/passes/test_tensor_partition.py
@@ -25,10 +25,10 @@ def vec(*vs):
 
 
 @pytest.fixture(scope='function')
-def mock_mpi_dist_env():
+def mock_dist_env():
     # The module is `...tensor_partition` because we have had
-    # `from import MPIDistEnv` therefore this ctor function is a new, standalone
-    # symbol in `...tensor_partition` module, no longer `...jit.runtime` module.
+    # `import get_dist_env` therefore this ctor function is a new, standalone
+    # symbol in `...tensor_partition` module, no longer `...dist_env` module.
     with patch(f'{CommPair.__module__}.{get_runtime_dist_env.__name__}') as ctor:
         mpi_mock = Mock(spec=_JitRuntimeDistEnv.DistEnv)
         mpi_mock.world_size = 2  # by default world_size = 2
@@ -45,30 +45,36 @@ PAR_PART_GRAPH_FUNCNAME = f'{CommPair.__module__}.{parallel_partition_graph.__na
 def get_call_arg0(call: 'mock.call_object'):  # type: ignore
     return call[0][0]
 
-def test_partition_tensor_groups(mock_mpi_dist_env):
+
+def test_partition_tensor_groups(mock_dist_env):
+    """
+    A0,...,A2,  B0,...,A4,   C0,...,C6,    # subadjmat for rank-0
+    A3,...,A5,  B5,...,A9,   C7,...,C13,   # subadjmat for rank-1
+    A6,...,A10, B10,...,B15, C14,...,C20,  # subadjmat for rank-2
+    """
     fake_defset = frozenset()
-    g5 = EasierTensorGroup(fake_defset, 11,  'g5')  # type: ignore
-    g6 = EasierTensorGroup(fake_defset, 16, 'g6')  # type: ignore
-    g7 = EasierTensorGroup(fake_defset, 21  'g7')  # type: ignore
+    A = EasierTensorGroup(fake_defset, 11, 'A')  # type: ignore
+    B = EasierTensorGroup(fake_defset, 16, 'B')  # type: ignore
+    C = EasierTensorGroup(fake_defset, 21, 'C')  # type: ignore
 
     def run(comm_pairs: List[CommPair]):
         return partition_tensor_groups_with_adjmat(
-            OrderedSet([g5, g6, g7]),
+            OrderedSet([A, B, C]),
             comm_pairs
         )
 
     comm_pairs_ranks: List[List[CommPair]] = [
         [
-            CommPair(g7, vec(1, 10, 18), g7, vec(15, 20, 3), False),
-            CommPair(g5, vec(7, 1, 5), g6, vec(9, 15, 4), False)
+            CommPair(C, vec(1, 10, 18), C, vec(15, 20, 3), False),
+            CommPair(A, vec(7, 1, 5), B, vec(9, 15, 4), False)
         ],
         [
-            CommPair(g7, vec(), g7, vec(), False),
-            CommPair(g5, vec(), g6, vec(), False)
+            CommPair(C, vec(), C, vec(), False),
+            CommPair(A, vec(), B, vec(), False)
         ],
         [
-            CommPair(g7, vec(), g7, vec(), False),
-            CommPair(g5, vec(), g6, vec(), False)
+            CommPair(C, vec(), C, vec(), False),
+            CommPair(A, vec(), B, vec(), False)
         ],
     ]
 
@@ -77,70 +83,50 @@ def test_partition_tensor_groups(mock_mpi_dist_env):
     # ================= rank 8calls tensors
     a2a_inputs: List[List[List[torch.Tensor]]] = [
         [
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
+            [vec(9), vec(11), vec(15)],     # C1 10 18 rowid
+            [vec(42), vec(47), vec(11)],    # C15 20 3 colid
+
+            [vec(11), vec(), vec(12, 17)],  # C15 20 3 rowid
+            [vec(45), vec(), vec(9, 26)],   # C1 10 18 colid
+
+            [vec(1), vec(2), vec(1)],       # A7 1 5 rowid
+            [vec(40), vec(7), vec(22)],     # B9 15 4 colid
+
+            [vec(7), vec(7), vec(10)],      # B9 15 4 rowid
+            [vec(17), vec(31), vec(1)],     # A7 1 5 colid
         ],
-        [ [vec() for _ in range(3)] for _ in range(8) ],
-        [ [vec() for _ in range(3)] for _ in range(8) ]
+        [[vec() for _ in range(3)] for _ in range(8)],
+        [[vec() for _ in range(3)] for _ in range(8)]
     ]
 
     a2a_outputs: List[List[List[torch.Tensor]]] = [
-        [
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-        ],
-        [
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-        ],
-        [
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-        ]
-
+        [[vec() for _ in range(3)] for _ in range(8)],
+        [[vec() for _ in range(3)] for _ in range(8)],
+        [[vec() for _ in range(3)] for _ in range(8)],
     ]
+    for sendrank in range(3):
+        for callid in range(8):
+            for recvrank in range(3):
+                a2a_outputs[recvrank][callid][sendrank] = \
+                    a2a_inputs[sendrank][callid][recvrank]
 
-    mock_mpi_dist_env.world_size = 3
+    mock_dist_env.world_size = 3
 
     for rank in range(3):
-        mock_mpi_dist_env.rank = rank
+        mock_dist_env.rank = rank
         with patch(PAR_PART_GRAPH_FUNCNAME) as mock_partgraph:
 
             mock_partgraph.return_value = [
                 "local_membership_not_used"
             ]
 
-            mock_mpi_dist_env.all_to_all.reset_mock()
-            mock_mpi_dist_env.all_to_all.side_effect = a2a_outputs[rank]
-            run(comm_pairs_ranks[mock_mpi_dist_env.rank])
+            mock_dist_env.all_to_all.reset_mock()
+            mock_dist_env.all_to_all.side_effect = a2a_outputs[rank]
+            run(comm_pairs_ranks[mock_dist_env.rank])
 
             mock_partgraph.assert_called_once()
 
-            call_args_list = iter(mock_mpi_dist_env.all_to_all.call_args_list)
+            call_args_list = iter(mock_dist_env.all_to_all.call_args_list)
 
             for expected_inputs, call_args in zip(
                 a2a_inputs[rank], call_args_list
@@ -149,316 +135,21 @@ def test_partition_tensor_groups(mock_mpi_dist_env):
                     get_call_arg0(call_args), expected_inputs
                 )
 
-@pytest.mark.skip
-def test_partition_tensor_groups2(mock_mpi_dist_env):
+
+def test_sync_parmetis_result(mock_dist_env):
+    """
+    A0,...,A2,  B0,...,A4,   C0,...,C6,    # subadjmat for rank-0
+    A3,...,A5,  B5,...,A9,   C7,...,C13,   # subadjmat for rank-1
+    A6,...,A10, B10,...,B15, C14,...,C20,  # subadjmat for rank-2
+    """
     fake_defset = frozenset()
-    g5 = EasierTensorGroup(fake_defset, 9,  'g5')  # type: ignore
-    g6 = EasierTensorGroup(fake_defset, 26, 'g6')  # type: ignore
-    g7 = EasierTensorGroup(fake_defset, 8,  'g7')  # type: ignore
-
-    def run(comm_pairs: List[CommPair]):
-        # `comm_pairs` can just be one-direction communication.
-        return partition_tensor_groups_with_adjmat(
-            {g5: 0, g6: 9, g7: 9 + 26},  # type: ignore
-            9 + 26 + 8,  # per_work=[15, 15, 13]
-            comm_pairs
-        )
-
-    mock_mpi_dist_env.world_size = 3
-
-    # assume idx of Selector/Reducer are evenly partitioned onto workers
-
-    mock_mpi_dist_env.rank = 0
-    with patch(PAR_PART_GRAPH_FUNCNAME) as mock_partgraph:
-
-        mock_partgraph.return_value = [
-            "local_membership_not_used"
-        ]
-
-        # - for each CommPair called four times:
-        #   --  send origin-direction rowids
-        #   --  send origin-direction colids
-        # ... then:
-        #   --  send symmetric rowids
-        #   --  send symmetric colids
-
-        recv_res = [
-            #
-            # CommPairs
-            #
-            # Select G7 to G7
-            # No data is located on worker-0
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            # symmetric:
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-
-            # Select G6 to G7
-            [vec(12), vec(13), vec()],
-            [vec(36), vec(40), vec()],
-            # symmetric:
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-
-            # Reduce G5 to G7
-            [vec(0, 1, 2),     vec(3, 4, 5),    vec(6, 7, 8)],
-            [vec(22, 14, 35),  vec(15, 15, 15), vec(29, 30, 29)],
-            # symmetric:
-            [vec(14), vec(), vec()],
-            [vec(1), vec(), vec()],
-        ]
-
-        mock_mpi_dist_env.all_to_all.reset_mock()
-        mock_mpi_dist_env.all_to_all.side_effect = recv_res
-
-        run([
-            CommPair(  # Select G7 to G7 itself
-                g7, vec(6, 2, 5),
-                g7, vec(0, 1, 2),   # Select dst is 1-1, total num is 8
-                False
-            ),
-            CommPair(  # Select G6 to G7, covering all 3 workers
-                g6, vec(22, 3, 11),
-                g7, vec(0, 1, 2),
-                False
-            ),
-            CommPair(  # Reduce G5 to G6
-                g5, vec(0, 1, 2),
-                g6, vec(13, 5, 21),
-                caused_by_reducer=True
-            )
-        ])
-
-        it = iter(mock_mpi_dist_env.all_to_all.call_args_list)
-        # Select G7 to G7
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(11, 7, 10)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(35, 36, 37)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(5, 6, 7)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(41, 37, 40)])
-
-        # Select G6 to G7
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(12), vec(5),   vec(1)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(36), vec(37),  vec(35)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(),      vec(), vec(5, 6, 7)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(),   vec(), vec(31, 12, 20)])
-
-        # Reduce G5 to G6
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(0, 1, 2), vec(), vec()])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(22, 14, 30), vec(), vec()])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(14), vec(7), vec(0)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(1), vec(0), vec(2)])
-
-        # all args are recv lengths, not necessary to check
-        # assert mock_irecv_ints.call_args_list == [ ... ]
-
-        mock_partgraph.assert_called_once()
-        # kwargs = mock_partgraph.call_args[1]
-        # local_rowids = kwargs['local_rowids']
-        # local_colids = kwargs['local_colids']
-
-    mock_mpi_dist_env.rank = 1
-    with patch(PAR_PART_GRAPH_FUNCNAME) as mock_partgraph:
-
-        mock_partgraph.return_value = [
-            "local_membership_not_used"
-        ]
-
-        recv_res = [
-            #
-            # CommPairs
-            #
-            # Select G7 to G7
-            # No data is located on worker-1
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            # symmetric:
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-
-            # Select G6 to G7
-            [vec(5),   vec(2, 3),      vec(14)],
-            [vec(37),  vec(38, 39),    vec(41)],
-            # symmetric:
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-
-            # Reduce G5 to G7
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            # symmetric:
-            [vec(7), vec(0, 0, 0), vec(14, 14)],
-            [vec(0), vec(3, 4, 5), vec(6, 7)],
-        ]
-        mock_mpi_dist_env.all_to_all.reset_mock()
-        mock_mpi_dist_env.all_to_all.side_effect = recv_res
-
-        run([
-            CommPair(  # G7 to G7 itself
-                g7, vec(1, 1, 1),
-                g7, vec(3, 4, 5),
-                False
-            ),
-            CommPair(  # Select G6 to G7, covering all 3 workers
-                g6, vec(8, 9, 4),
-                g7, vec(3, 4, 5),
-                False
-            ),
-            CommPair(  # Reduce G5 to G6
-                g5, vec(3, 4, 5),
-                g6, vec(6, 6, 6),
-                True
-            )
-        ])
-
-        it = iter(mock_mpi_dist_env.all_to_all.call_args_list)
-        # Select G7 to G7
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(6, 6, 6)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(38, 39, 40)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(8, 9, 10)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(36, 36, 36)])
-
-        # Select G6 to G7
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(13), vec(2, 3), vec()])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(40), vec(38, 39), vec()])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(8, 9, 10)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(17, 18, 13)])
-
-        # Reduce G5 to G7
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(3, 4, 5), vec(), vec()])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(15, 15, 15), vec(), vec()])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(0, 0, 0), vec()])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(3, 4, 5), vec()])
-
-        # all args are recv lengths, not necessary to check
-        # assert mock_irecv_ints.call_args_list == [ ... ]
-
-        mock_partgraph.assert_called_once()
-
-    mock_mpi_dist_env.rank = 2
-    with patch(PAR_PART_GRAPH_FUNCNAME) as mock_partgraph:
-
-        mock_partgraph.return_value = [
-            "local_membership_not_used"
-        ]
-
-        recv_res = [
-            #
-            # CommPairs
-            #
-            # Select G7 to G7
-            [vec(11, 7, 19),   vec(6, 6, 6),       vec(5, 9)],
-            [vec(35, 36, 37),  vec(38, 39, 40),    vec(41, 42)],
-            # symmetric:
-            [vec(5, 6, 7),     vec(8, 9, 10),      vec(11, 12)],
-            [vec(41, 37, 40),  vec(36, 36, 36),    vec(35, 39)],
-
-            # Select G6 to G7
-            [vec(1), vec(), vec(0)],
-            [vec(35), vec(), vec(42)],
-            # symmetric:
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-
-            # Reduce G5 to G7
-            [vec(), vec(), vec()],
-            [vec(), vec(), vec()],
-            # symmetric:
-            [vec(0), vec(), vec(0)],
-            [vec(2), vec(), vec(7)],
-        ]
-        mock_mpi_dist_env.all_to_all.reset_mock()
-        mock_mpi_dist_env.all_to_all.side_effect = recv_res
-
-        run([
-            CommPair(  # G7 to G7 itself
-                g7, vec(0, 4),
-                g7, vec(6, 7),
-                False
-            ),
-            CommPair(  # Select G6 to G7, covering all 3 workers
-                g6, vec(20, 21),
-                g7, vec(6, 7),
-                False
-            ),
-            CommPair(  # Reduce G5 to G6
-                g5, vec(6, 7, 8),
-                g6, vec(20, 21, 20),
-                True
-            )
-        ])
-
-        it = iter(mock_mpi_dist_env.all_to_all.call_args_list)
-        # Select G7 to G7
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(5, 9)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(41, 42)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(11, 12)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(35, 39)])
-
-        # Select G6 to G7
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(14), vec(0)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(41), vec(42)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(11, 12)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(), vec(29, 30)])
-
-        # Reduce G5 to G7
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(6, 7, 8), vec(), vec()])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(29, 30, 29), vec(), vec()])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(14, 14), vec(0)])
-        assert_tensor_list_equal(get_call_arg0(next(it)),
-                                 [vec(), vec(6, 8), vec(7)])
-
-        mock_partgraph.assert_called_once()
-
-
-def test_sync_parmetis_result(mock_mpi_dist_env):
-    world_size = 3
-    mock_mpi_dist_env.world_size = world_size
-
-    fake_defset = frozenset()
-    g5 = EasierTensorGroup(fake_defset, 9,  'g5')  # type: ignore
-    g6 = EasierTensorGroup(fake_defset, 26, 'g6')  # type: ignore
-    g7 = EasierTensorGroup(fake_defset, 8,  'g7')  # type: ignore
+    A = EasierTensorGroup(fake_defset, 11, 'A')  # type: ignore
+    B = EasierTensorGroup(fake_defset, 16, 'B')  # type: ignore
+    C = EasierTensorGroup(fake_defset, 21, 'C')  # type: ignore
 
     def run(local_membership: torch.Tensor):
         r = synchronize_partition_result(
-            {g5: 0, g6: 9, g7: 9 + 26},  # type: ignore
-            9 + 26 + 8,  # per_work=[15, 15, 13]
+            OrderedSet([A, B, C]),
             local_membership
         )
         for k, v in r.items():
@@ -466,104 +157,74 @@ def test_sync_parmetis_result(mock_mpi_dist_env):
 
         return r
 
-    g5_w0_to_w0 = vec(0, 1, 6)
-    g5_w0_to_w1 = vec(2, 3, 7)
-    g5_w0_to_w2 = vec(4, 5, 8)
-    g5_w1_to_w0 = vec()
-    g5_w1_to_w1 = vec()
-    g5_w1_to_w2 = vec()
-    g5_w2_to_w0 = vec()
-    g5_w2_to_w1 = vec()
-    g5_w2_to_w2 = vec()
-
-    g6_w0_to_w0 = vec()
-    g6_w0_to_w1 = vec(0, 4, 5)
-    g6_w0_to_w2 = vec(1, 2, 3)
-    g6_w1_to_w0 = vec(6, 9, 12, 13, 14)
-    g6_w1_to_w1 = vec(7, 10, 15, 16, 17)
-    g6_w1_to_w2 = vec(8, 11, 18, 19, 20)
-    g6_w2_to_w0 = vec(22, 24, 25)
-    g6_w2_to_w1 = vec(21, 23)
-    g6_w2_to_w2 = vec()
-
-    g7_w0_to_w0 = vec()
-    g7_w0_to_w1 = vec()
-    g7_w0_to_w2 = vec()
-    g7_w1_to_w0 = vec()
-    g7_w1_to_w1 = vec()
-    g7_w1_to_w2 = vec()
-    g7_w2_to_w0 = vec(0, 1, 2, 3)
-    g7_w2_to_w1 = vec(4, 5, 6, 7)
-    g7_w2_to_w2 = vec()
-
-    mock_mpi_dist_env.rank = 0
-    recv_res = [
-        [g5_w0_to_w0, g5_w1_to_w0, g5_w2_to_w0],
-        [g6_w0_to_w0, g6_w1_to_w0, g6_w2_to_w0],
-        [g7_w0_to_w0, g7_w1_to_w0, g7_w2_to_w0],
-    ]
-    mock_mpi_dist_env.all_to_all.reset_mock()
-    mock_mpi_dist_env.all_to_all.side_effect = recv_res
-
-    run(
+    local_memberships = [
         vec(
-            0, 0, 1, 1, 2, 2, 0, 1, 2,  # g5 on w0
-            1, 2, 2, 2, 1, 1  # g6[:6] on w0
-        )
-    )
-
-    it = iter(mock_mpi_dist_env.all_to_all.call_args_list)
-    assert_tensor_list_equal(get_call_arg0(next(it)),
-                             [g5_w0_to_w0, g5_w0_to_w1, g5_w0_to_w2])
-    assert_tensor_list_equal(get_call_arg0(next(it)),
-                             [g6_w0_to_w0, g6_w0_to_w1, g6_w0_to_w2])
-    assert_tensor_list_equal(get_call_arg0(next(it)),
-                             [g7_w0_to_w0, g7_w0_to_w1, g7_w0_to_w2])
-
-    mock_mpi_dist_env.rank = 1
-    recv_res = [
-        [g5_w0_to_w1, g5_w1_to_w1, g5_w2_to_w1],
-        [g6_w0_to_w1, g6_w1_to_w1, g6_w2_to_w1],
-        [g7_w0_to_w1, g7_w1_to_w1, g7_w2_to_w1],
-    ]
-    mock_mpi_dist_env.all_to_all.reset_mock()
-    mock_mpi_dist_env.all_to_all.side_effect = recv_res
-    run(
+            0, 1, 2,
+            0, 1, 2, 1, 0,
+            1, 1, 0, 0, 2, 2, 1,
+        ),
         vec(
-            0, 1, 2, 0, 1, 2, 0, 0, 0, 1, 1, 1, 2, 2, 2,  # g6[6:21] on w1
-        )
-    )
-
-    it = iter(mock_mpi_dist_env.all_to_all.call_args_list)
-    assert_tensor_list_equal(get_call_arg0(next(it)),
-                             [g5_w1_to_w0, g5_w1_to_w1, g5_w1_to_w2])
-    assert_tensor_list_equal(get_call_arg0(next(it)),
-                             [g6_w1_to_w0, g6_w1_to_w1, g6_w1_to_w2])
-    assert_tensor_list_equal(get_call_arg0(next(it)),
-                             [g7_w1_to_w0, g7_w1_to_w1, g7_w1_to_w2])
-
-    mock_mpi_dist_env.rank = 2
-    recv_res = [
-        [g5_w0_to_w2, g5_w1_to_w2, g5_w2_to_w2],
-        [g6_w0_to_w2, g6_w1_to_w2, g6_w2_to_w2],
-        [g7_w0_to_w2, g7_w1_to_w2, g7_w2_to_w2],
-    ]
-    mock_mpi_dist_env.all_to_all.reset_mock()
-    mock_mpi_dist_env.all_to_all.side_effect = recv_res
-
-    run(
+            1, 0, 2,
+            2, 0, 1, 0, 2,
+            0, 1, 0, 1, 2, 0, 1
+        ),
         vec(
-            1, 0, 1, 0, 0,  # g6[21:] on w1
-            0, 0, 0, 0, 1, 1, 1, 1  # g7 on w2
-        )
-    )
-    it = iter(mock_mpi_dist_env.all_to_all.call_args_list)
-    assert_tensor_list_equal(get_call_arg0(next(it)),
-                             [g5_w2_to_w0, g5_w2_to_w1, g5_w2_to_w2])
-    assert_tensor_list_equal(get_call_arg0(next(it)),
-                             [g6_w2_to_w0, g6_w2_to_w1, g6_w2_to_w2])
-    assert_tensor_list_equal(get_call_arg0(next(it)),
-                             [g7_w2_to_w0, g7_w2_to_w1, g7_w2_to_w2])
+            1, 1, 1, 1, 1,
+            0, 0, 0, 0, 0, 0,
+            2, 2, 2, 2, 2, 2, 2
+        ),
+    ]
+
+    # ========  rank 3grp inputs
+    a2a_inputs: List[List[List[torch.Tensor]]] = [
+        [
+            [vec(0), vec(1), vec(2)],  # A
+            [vec(0, 4), vec(1, 3), vec(2)],  # B
+            [vec(2, 3,), vec(0, 1, 6), vec(4, 5)],  # C
+        ],
+        [
+            [vec(4), vec(3), vec(5)],
+            [vec(6, 8), vec(7), vec(5, 9)],
+            [vec(7, 9, 12), vec(8, 10, 13), vec(11)],
+        ],
+        [
+            [vec(), vec(6, 7, 8, 9, 10), vec()],
+            [vec(10, 11, 12, 13, 14, 15), vec(), vec()],
+            [vec(), vec(), vec(14, 15, 16, 17, 18, 19, 20)],
+        ]
+    ]
+
+    a2a_outputs: List[List[List[torch.Tensor]]] = [
+        [[vec() for _ in range(3)] for _ in range(3)],
+        [[vec() for _ in range(3)] for _ in range(3)],
+        [[vec() for _ in range(3)] for _ in range(3)],
+    ]
+    for sendrank in range(3):
+        for callid in range(3):
+            for recvrank in range(3):
+                a2a_outputs[recvrank][callid][sendrank] = \
+                    a2a_inputs[sendrank][callid][recvrank]
+
+    mock_dist_env.world_size = 3
+
+    for rank in range(3):
+        mock_dist_env.rank = rank
+        mock_dist_env.all_to_all.reset_mock()
+        mock_dist_env.all_to_all.side_effect = a2a_outputs[rank]
+        run(local_memberships[rank])
+
+        call_args_list = iter(mock_dist_env.all_to_all.call_args_list)
+
+        for expected_inputs, call_args in zip(
+            a2a_inputs[rank], call_args_list
+        ):
+            assert_tensor_list_equal(
+                get_call_arg0(call_args), expected_inputs
+            )
+
+        # NOTE as we don't mock all_gather_into_tensor, the last part of
+        # sync_partition_result won't result in ElemParts, but a series of
+        # Mock objects.
 
 
 @pytest.mark.usefixtures('dummy_dist_env')

--- a/tests/core/test_jit.py
+++ b/tests/core/test_jit.py
@@ -582,10 +582,10 @@ class NotFullModel(esr.Module):
             torch.arange(2, 38).reshape(-1, 2).double(), mode='partition'
         )
         self.edge = esr.Tensor(
-            torch.arange(2, 8).reshape(-1, 2).double(), mode='partition'
+            torch.arange(2, 12).reshape(-1, 2).double(), mode='partition'
         )
-        self.selector = esr.Selector(torch.arange(3) // 2)
-        self.reducer = esr.Reducer(torch.ones(3, dtype=torch.int64), n=18)
+        self.selector = esr.Selector(torch.arange(5) // 2)
+        self.reducer = esr.Reducer(torch.ones(5, dtype=torch.int64), n=18)
         self.replica = esr.Tensor(
             torch.zeros([1, 2]).double(), mode='replicate'
         )

--- a/tests/core/utils.py
+++ b/tests/core/utils.py
@@ -99,8 +99,7 @@ def multi_stage_zero_length_partition(
         return local_membership
 
     def _sync_elempart_0len(
-        tensor_group_to_matedge_offsets,
-        accum_n: int,
+        tensor_groups,
         local_membership: torch.Tensor  # many 0s, polluted by prev patches
     ):
         # grp1 selected to grp2, grp2 reduced to grp1
@@ -110,9 +109,7 @@ def multi_stage_zero_length_partition(
         assert isinstance(grp1, EasierTensorGroup)
         assert isinstance(grp2, EasierTensorGroup)
 
-        elemparts = _sync_elempart(
-            tensor_group_to_matedge_offsets, accum_n, local_membership
-        )
+        elemparts = _sync_elempart(tensor_groups, local_membership)
         for grp, ep in list(elemparts.items()):
             #       grp1    grp2
             # rank0  X       X  # removed, aligns with kway deselects rank-0


### PR DESCRIPTION
Main changes:
- Refactored tensor_group_partition pass, adjusted how we distribute the adjmat for distpart/METIS.
  - Previously we simply-and-conceptually concat all TensorGroups and then evenly distribute the adjmat, the main issue is that the calculation for this is complex, also, this leads to unbalanced distribution of nonzero entities in the adjmat.
  - Now we evenly distribute each TensorGroup and each worker has one piece of each TensorGroup.
- Introduce a general mechanism `dist_env.unbalanced_compute_heartbeat` to avoid collective call timeout due to unbalanced workload.
  - The timeout happens when some workers have lighter workload and enter the collective call earlier. If other workers take a long time to finish calculate, the workers who entered earlier would timeout. Instead of manually and ad hoc configuring the timeout threshold, we'll stably keep communication environment healthy.
  - All heavy, possible unbalanced workloads are now guarded by `unbalanced_compute_heartbeat`.