### PR TITLE
Refine reducer_binding pass; JitEngine checks Tensor.storage

### DIFF
--- a/easier/core/module.py
+++ b/easier/core/module.py
@@ -834,7 +834,11 @@ def sum(tensor: torch.Tensor) -> torch.Tensor:
     -   tensor:
         At JIT-time, must be a distributed tensor.
     """
-    return _allreduce(torch.sum, tensor)
+    # Unless specifying `dtype=`, some dtypes like int32 may get promoted to
+    # int64 implicitly.
+    # TODO overflow-prone aggregators esr.xxx should support dtype etc.
+    # parameters like their torch.xxx counterparts.
+    return _allreduce(torch.sum, tensor, dtype=tensor.dtype)
 
 
 def prod(tensor: torch.Tensor) -> torch.Tensor:
@@ -845,7 +849,7 @@ def prod(tensor: torch.Tensor) -> torch.Tensor:
     -   tensor:
         At JIT-time, must be a distributed tensor.
     """
-    return _allreduce(torch.prod, tensor)
+    return _allreduce(torch.prod, tensor, dtype=tensor.dtype)
 
 
 def norm(tensor: torch.Tensor, p: Union[int, str] = 2) -> torch.Tensor:
@@ -856,7 +860,7 @@ def norm(tensor: torch.Tensor, p: Union[int, str] = 2) -> torch.Tensor:
     -   tensor:
         At JIT-time, must be a distributed tensor.
     """
-    return _allreduce(torch.norm, tensor, p)
+    return _allreduce(torch.norm, tensor, p, dtype=tensor.dtype)
 
 
 def max(tensor: torch.Tensor) -> torch.Tensor:

--- a/easier/core/passes/reducer_binding.py
+++ b/easier/core/passes/reducer_binding.py
@@ -43,18 +43,22 @@ class ReducerBinder(EasierInterpreter[None]):
         nnodes[submod] = nnodes.get(submod, 0) + 1
 
 
-class CsrSelectorInserter(EasierInterpreter[None]):
+class CsrSelectorCallInserter(EasierInterpreter[None]):
     def __init__(
         self, modules: Sequence[esr.Module], graphs: Sequence[Graph],
-        tgrp2reducer: Dict[EasierTensorGroup, esr.Reducer]
+        csr_selectors: Dict[esr.Reducer, esr.Selector]
     ) -> None:
         super().__init__(modules, graphs)
 
-        self.tgrp2reducer = tgrp2reducer
+        self.csr_selectors = csr_selectors
         self.selector_name_allocator = SubmodNameAllocator('csr_selector')
 
     def if_call_module(self, submod: nn.Module) -> None:
         if not isinstance(submod, esr.Reducer):
+            return
+
+        if submod not in self.csr_selectors:
+            # Reducers that do not need CSR Selectors are not included.
             return
 
         args = self.current_node.args
@@ -63,58 +67,51 @@ class CsrSelectorInserter(EasierInterpreter[None]):
             normalize_reducer_call_into_args(*args, **kwargs)
         assert isinstance(input_node, Node)
 
-        tgrp = get_node_tensor_group(input_node)
-        assert tgrp is not None
+        csr_selector = self.csr_selectors[submod]
 
-        bound_reducer = self.tgrp2reducer[tgrp]
-        if bound_reducer is not submod:
+        # OK to add names per-Node.
+        selector_attrname = self.selector_name_allocator.alloc_name(
+            self.current_module, hint=self.current_node.name
+        )
+        self.current_module.add_module(selector_attrname, csr_selector)
 
-            # TODO reuse selector instance if <tgrp, reducer> met.
-
-            selector_attrname = self.selector_name_allocator.alloc_name(
-                self.current_module, hint=self.current_node.name
+        with self.current_graph.inserting_before(self.current_node):
+            csr_selector_node = self.current_graph.call_module(
+                selector_attrname, (input_node,)
+            )
+            self.current_node.replace_input_with(
+                input_node, csr_selector_node
             )
 
-            # Collectively create and insert.
-            # During module dumping, this Selector will be dumped
-            # as normal Selectors, and during loading this Selector will be
-            # created again -- it's ok as this is merely a data loader,
-            # till its `.idx` get directly overwritten with the loaded data.
-            csr_selector = esr.Selector(esr.arange(
-                submod.easier_data_loader.shape[0],
-                dtype=submod.easier_data_loader.dtype,
-                device=submod.easier_data_loader.device
-            ))
-            csr_selector.easier_hint_name = \
-                f"{submod.easier_hint_name}.{selector_attrname}"
-            # TODO if we reuse the Selector instance the naming will be
-            # as consistent as dataflow_distribution
-            # f"{submod.easier_hint_name}.reorderingSelector"
-
-            self.current_module.add_module(selector_attrname, csr_selector)
-
-            with self.current_graph.inserting_before(self.current_node):
-                csr_selector_node = self.current_graph.call_module(
-                    selector_attrname, (input_node,)
-                )
-                self.current_node.replace_input_with(
-                    input_node, csr_selector_node
-                )
-
-            logger.info(f"Insert arange-Selector for {self.current_node.name}")
+        logger.info(
+            f"Insert call to {csr_selector.easier_hint_name}"
+            f" for {self.current_node.name}"
+        )
 
 
 def bind_reducer(modules: List[esr.Module], graphs: List[Graph]):
     """
     Analyze which Reducer decides (CSR-encoded) layout of each tensor.
-    If one tensor is used by multiple Reducers, insert Selectors for
+    If one TensorGroup is used by multiple Reducers, insert Selectors for
     extra Reducers.
+
+    After the insertion of such _CSR Selectors_, the input TensorGroups of
+    Reducers are mutually isolated.
+    Therefore, during TensorGroup partitioning, the partitioning on I/O
+    TensorGroups of a Reducer won't affect the partitioning for other Reducers,
+    and each of them can be tuned to the best.
+
+    NOTE However, due to the heuristic nature of partitioning, occasionally a
+    Reducer may still need data exchange (HaloExchanger), for such edge cases,
+    a _reordering Selector_ will be added, which is for memory locality
+    and not the same as _CSR Selector_ here.
     """
     reducer_binder = ReducerBinder(modules, graphs)
     reducer_binder.run()
 
-    # pick one Reducer instance with the maximum number of Nodes.
-    target_reducers: Dict[EasierTensorGroup, esr.Reducer] = {}
+    # Reducers that do not need CSR Selectors are not included.
+    csr_selectors: Dict[esr.Reducer, esr.Selector] = {}
+    
     for grp, reducer2nnodes in reducer_binder.tengrp2reducer.items():
 
         # If multiple Reducers are reducing the same input tensor group,
@@ -129,11 +126,30 @@ def bind_reducer(modules: List[esr.Module], graphs: List[Graph]):
             ((float(r.easier_data_loader.count_unique()) / r.n, nnodes), r)
             for r, nnodes in reducer2nnodes.items()
         ]
-        _maxweight, target = max(weighted_reducers, key=lambda tp: tp[0])
+        _maxweight, main_reducer = max(weighted_reducers, key=lambda tp: tp[0])
 
-        target_reducers[grp] = target
+        for reducer, nnodes in reducer2nnodes.items():
+            if reducer is main_reducer:
+                continue
 
-    selector_inserter = CsrSelectorInserter(modules, graphs, target_reducers)
+            # Prepare a CSR Selector
+            # (without validation like passes/collective_initialization.py)
+            #
+            # During module dumping, this Selector will be dumped
+            # as normal Selectors, and during loading this Selector will be
+            # created again -- it's ok as this is merely a data loader,
+            # till its `.idx` get directly overwritten with the loaded data.
+            csr_selector = esr.Selector(esr.arange(
+                reducer.easier_data_loader.shape[0],
+                dtype=reducer.easier_data_loader.dtype,
+                device=reducer.easier_data_loader.device
+            ))
+            csr_selector.easier_hint_name = \
+                f"{reducer.easier_hint_name}.CSRSelector"
+            
+            csr_selectors[reducer] = csr_selector
+
+    selector_inserter = CsrSelectorCallInserter(modules, graphs, csr_selectors)
     selector_inserter.run()
 
     return modules, graphs

--- a/easier/core/runtime/jit_engine/jit_engine.py
+++ b/easier/core/runtime/jit_engine/jit_engine.py
@@ -467,7 +467,7 @@ class ViewSrcTracker(ViewSrcTrackerBase):
         post_eval_args_siaddrs = self._get_args_siaddrs(current_node)
         if post_eval_args_siaddrs != self.args_siaddrs:
             raise EasierJitException(
-                f"The operation {current_node.format_node()} is not allowed,"
+                f"The operation '{current_node.format_node()}' is not allowed,"
                 " because it changes the storage of the input tensor"
             )
 

--- a/easier/core/runtime/jit_engine/jit_engine.py
+++ b/easier/core/runtime/jit_engine/jit_engine.py
@@ -253,17 +253,8 @@ class ViewSrcTrackerBase(NodeHandlerBase):
         self.addr2refcount: Dict[int, int] = {}
         self.addr2viewsrc: Dict[int, ViewSrc] = {}
 
-        # TODO record (within storage lifetime) the address of a tensor,
-        # we need the invariant that tensor storage never changes
-        # because they are allocated by EASIER AOT.
-        # E.g. Tensor.set_ resets the storage, but Tensor.copy_ does not.
-        # self.tensor2addr: Dict[torch.Tensor, int] = {}
-        #
-        # NOTE but if it's not an esr.Tensor, but an immediate tensors, can
-        # their storage be changed? We can detect the change and decr refcount
-        # before resetting and incr refcount of the shared storage.
 
-    def _get_indexed_addr(
+    def get_indexed_addr(
         self, iaddr_node: Node, val: RuntimeValue,
         *,
         _rec_depth=0  # debug-only
@@ -298,7 +289,7 @@ class ViewSrcTrackerBase(NodeHandlerBase):
 
             indexed_addrs = []
             for i, item in enumerate(val):
-                item_iaddr = self._get_indexed_addr(
+                item_iaddr = self.get_indexed_addr(
                     iaddr_node, item,
                     _rec_depth=_rec_depth+1
                 )
@@ -336,7 +327,7 @@ class ViewSrcTrackerBase(NodeHandlerBase):
         # Increase ref count;
         # If previous ref count is 0, set current_node as ViewSrc.
         #
-        res_siaddr: StructuredIndexedAddr = self._get_indexed_addr(
+        res_siaddr: StructuredIndexedAddr = self.get_indexed_addr(
             current_node, res
         )
 
@@ -413,7 +404,7 @@ class ViewSrcTrackerBase(NodeHandlerBase):
             # NOTE currently for the sake of simplicity _get_indexed_addr()
             # cannot handle nester layer > 1, so we cannot concat `env_val`s
             # into a list first.
-            end_siaddr: StructuredIndexedAddr = self._get_indexed_addr(
+            end_siaddr: StructuredIndexedAddr = self.get_indexed_addr(
                 node_ends_here, end_val
             )
             end_item_iaddrs: List[IndexedAddr] = collect_meta(
@@ -436,6 +427,52 @@ class ViewSrcTrackerBase(NodeHandlerBase):
 
 
 class ViewSrcTracker(ViewSrcTrackerBase):
+    """
+    Calculate ViewSrcs of evaluated results and record them in the Node.
+
+    Additional to ViewSrc, only in the 1st run do we check
+    against operations that change the storage of tensor,
+    for example, Tensor.set_, Tensor.resize_.
+    """
+    def _get_args_siaddrs(self, current_node: Node):
+        # Simply store the flattened IndexAddr objects.
+        args_siaddrs = []
+
+        for arg_node in current_node.all_input_nodes:
+            arg_val = self.stackframe[arg_node]
+            arg_siaddr: StructuredIndexedAddr = self.get_indexed_addr(
+                arg_node, arg_val
+            )
+            args_siaddrs.append(arg_siaddr)
+        return args_siaddrs
+
+    def preprocess(
+        self,
+        current_node: Node,
+        args: List[RuntimeValue],
+        kwargs: Dict[str, RuntimeValue]
+    ) -> PreprocessDecision:
+        # Record (within storage lifetime) the address of a tensor,
+        # we need the invariant that tensor storage never changes
+        # because they are allocated by EASIER AOT or managed by codegen.
+        # E.g. Tensor.set_ resets the storage, but Tensor.copy_ does not.
+        self.args_siaddrs: List[StructuredIndexedAddr] = \
+            self._get_args_siaddrs(current_node)
+
+        return PreprocessDecision.CONTINUE
+
+    def postprocess(
+        self, current_node: Node, res: RuntimeValue, args, kwargs
+    ) -> RuntimeValue:
+        post_eval_args_siaddrs = self._get_args_siaddrs(current_node)
+        if post_eval_args_siaddrs != self.args_siaddrs:
+            raise EasierJitException(
+                f"The operation {current_node.format_node()} is not allowed,"
+                " because it changes the storage of the input tensor"
+            )
+
+        return super().postprocess(current_node, res, args, kwargs)
+        
     def handle_view_src(
         self, current_node: Node, view_src: StructuredViewSrc
     ) -> None:
@@ -1038,8 +1075,8 @@ class JitEngine:
             # <- Store result into stackframe, release unused tensors
             StackframeManager(self.module, stackframe),
 
-            # ->
-            # <- Updates refcount and sets view_src
+            # -> Records tensor storage info
+            # <- Detects storage changes; Updates refcount and sets view_src
             ViewSrcTracker(self.module, stackframe),
 
             # -> Calculates expected role and batchsize --/


### PR DESCRIPTION
Main changes:
- reducer_binding used to create Selectors for each relevant Nodes, which may lead to too many Selectors with the same idx to be added. Now refined to create for each relevant Reducer.
- JitEngine 1st run checks input Tensors' storages/allocated memories are not changed by ops like `set_, resize_`.
- Make aggregator `esr.sum/prod/norm` returns the same dtype as input. Unlike `torch.sum/...` which implicitly promote int dtypes to int64.
  - `torch.amax/amin` do not accept dtype arg as they are free from overflow.